### PR TITLE
Fix for null request dictionary keys.

### DIFF
--- a/Lastfm/Api/BaseLastfmApiClient.cs
+++ b/Lastfm/Api/BaseLastfmApiClient.cs
@@ -34,7 +34,10 @@
         /// <returns>A response with type TResponse</returns>
         public async Task<TResponse> Post<TRequest, TResponse>(TRequest request) where TRequest : BaseRequest where TResponse : BaseResponse
         {
-            var data = request.ToDictionary();
+            // remove any keys where the values == null .
+            var data = request.ToDictionary()
+                    .Where(k => !string.IsNullOrWhiteSpace(k.Value))
+                    .ToDictionary(k => k.Key, k => k.Value);
 
             //Append the signature
             Helpers.AppendSignature(ref data);


### PR DESCRIPTION
This fixes https://github.com/MediaBrowser/Last.fm/issues/5

The change removes any null value (and its associated key) from the `TRequest` object. 